### PR TITLE
Adding the possibility to filter out the classes to show

### DIFF
--- a/bin/json-to-plantuml.js
+++ b/bin/json-to-plantuml.js
@@ -6,8 +6,8 @@ var _ = require("lodash"),
     request = require('request'),
     argv = require('minimist')(process.argv.slice(2));
 
-function jsonToPlantuml(jsonData) {
-    plantumlify(jsonData)
+function jsonToPlantuml(jsonData, ignore_list) {
+    plantumlify(jsonData, ignore_list)
         .then(console.log)
         .catch(console.log);
 }
@@ -15,20 +15,26 @@ function jsonToPlantuml(jsonData) {
 if (process.stdin.isTTY) {
     // handle shell arguments
     var filepath = argv._[0] || argv.f;
+    var ignore = argv.i;
+    var ignore_list = []
     var url = argv.u;
+
+    if (ignore!= undefined)  {
+        ignore_list = ignore.split(",")
+    }
 
     if (filepath != undefined) {
         fs.readFile(filepath, 'utf8', function (err, data) {
             if (err) {
                 return console.log(err);
             }
-            jsonToPlantuml(data);
+            jsonToPlantuml(data, ignore_list);
         });
     }
     else if (url != undefined) {
         request(url, function (err, response, data) {
             if (!error && response.statusCode == 200) {
-                jsonToPlantuml(data);
+                jsonToPlantuml(data, ignore_list);
             } else {
                 return console.log(err);
             }
@@ -41,18 +47,21 @@ if (process.stdin.isTTY) {
 } else {
     // handle piped content 
     var input = [];
+    if (ignore!= undefined)  {
+        ignore_list = ignore.split(",")
+    }
     var stream = byline(process.stdin);
     stream.on("data", function (line) {
         input.push(line + "");
     }).on("end", function () {
-        jsonToPlantuml(input.join("\n"));
+        jsonToPlantuml(input.join("\n"), ignore_list);
     });
 }
 
 function printHelp() {
     console.log(`
 Usage:
-    json-to-plantuml [filepath|-f filepath|-u filepath]
+    json-to-plantuml [filepath|-f filepath -i ignore (classes separated by ",")|-u filepath]
     json-to-plantuml <filepath>
 
 Options:

--- a/lib/plantumlify.js
+++ b/lib/plantumlify.js
@@ -78,7 +78,7 @@ function prepareForPlantuml(str) {
 	return str.replace(/\s/g, "_").replace(/\</g, "_lt_").replace(/\>/g, "_gt_");
 }
 
-function traverse(obj, parent) {
+function traverse(obj, ignore_list, parent) {
     var maxWidth = 32;
     var splittingStr = "\\n";
     var newObj = [];
@@ -111,8 +111,8 @@ function traverse(obj, parent) {
                     clsObjects: objChildObjectsStr
                 });
 
-                if (!_.isEmpty(objChildObjects)) {
-                    var tmp = traverse(objChildObjects, (parent != undefined ? `${parent}.${key}` : key));
+                if (!_.isEmpty(objChildObjects) && !(ignore_list.includes(key))) {
+                    var tmp = traverse(objChildObjects, ignore_list, (parent != undefined ? `${parent}.${key}` : key));
 
                     tmp.objRelations.forEach(function (rel, index) {
                         objRelations.push(rel);
@@ -141,7 +141,7 @@ function traverse(obj, parent) {
     }
 }
 
-module.exports = function (input) {
+module.exports = function (input, ignore_list) {
 
     return new Promise(function (resolve, reject) {
         var json;
@@ -165,6 +165,6 @@ module.exports = function (input) {
             json = { "root": json };
         };
 
-        resolve(template(traverse(json)));
+        resolve(template(traverse(json, ignore_list)));
     });
 };


### PR DESCRIPTION
Hi,

First of all thanks for sharing your work. When the JSON is very big, I think that is useful to be able to hide some classes. I have made a modification to filter out some classes passed in the command line. If you consider, you can merge the code with yours.

It works like this:

>json-to-plantuml -f product.json -i price,standalonePrice,finalPrice,productTotalPrice,characteristic,productPrice,productTotalPrice 

